### PR TITLE
debug switch added to the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Power Monitor
-Another stupidly simple KDE Plasma 5 widget to monitor the power consumption of your CPU (only) in real time.
+Another stupidly simple KDE Plasma 5 widget to monitor the power consumption of your CPU and AMD GPU in real time.
 
-This is a fork of [Power Monitor](https://github.com/atul-g/plasma-power-monitor). The original measures the battery power consumption while this extension measures only <b>Intel</b> CPU's power.
+This is a fork of [Power Monitor](https://github.com/atul-g/plasma-power-monitor). The original measures the battery power consumption while this extension measures <b>Intel</b> CPU's power. This version adds support for AMD GPU power monitoring.
 
 ## Preview
 Widget as shown on desktop
@@ -21,7 +21,8 @@ To install this, right click on the desktop, click on `Add Widgets`, select `Get
 
 1. Update Interval: Changes the rate at which the widget updates
 2. Bold Text: Changes display text to <b>Bold</b>
-3. Add "Fix Permission" to CronJobs: Adds a cron job to <b> root's </b> cron list to fix sensor permission when the system reboots. When clicked,
+3. Enable AMD GPU Power Monitoring: If checked, displays AMD GPU power consumption below CPU power. The widget automatically detects the correct sysfs path for the GPU power sensor.
+4. Add "Fix Permission" to CronJobs: Adds a cron job to <b> root's </b> cron list to fix sensor permission when the system reboots. When clicked,
    * If it asked for the sudo password <b> twice</b>, this fix is successfully installed.
    * If it asked for the sudo password only <b> once</b>, the fix is already installed.
 
@@ -40,4 +41,4 @@ To install this, right click on the desktop, click on `Add Widgets`, select `Get
     
     * running `sudo chmod 444 /sys/class/powercap/intel-rapl:0/energy_uj` in konsole and see if the issue is fixed. (Temporary, resets on reboot)
 4. The power usage rises continously when the laptop is plugged in to A/C power. It is normal if you see high readings.
-5. This will only work for <b>Intel CPUs</b>.
+5. This will work for <b>Intel CPUs</b> and optionally <b>AMD GPUs</b> if enabled in settings.

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -17,5 +17,10 @@
       <whatsthis>Use bold text</whatsthis>
       <default>false</default>
     </entry>
+    <entry name="debug" type="Bool">
+      <label>Enable Debug Logging</label>
+      <whatsthis>If enabled, logs will be printed to the system journal. Disable to suppress logs.</whatsthis>
+      <default>false</default>
+    </entry>
   </group>
 </kcfg>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -22,5 +22,10 @@
       <whatsthis>If enabled, logs will be printed to the system journal. Disable to suppress logs.</whatsthis>
       <default>false</default>
     </entry>
+    <entry name="enableGPU" type="Bool">
+      <label>Enable AMD GPU Power Monitoring</label>
+      <whatsthis>If enabled, attempts to monitor AMD GPU power consumption in addition to CPU.</whatsthis>
+      <default>false</default>
+    </entry>
   </group>
 </kcfg>

--- a/package/contents/ui/ConfigGeneral.qml
+++ b/package/contents/ui/ConfigGeneral.qml
@@ -8,6 +8,7 @@ SimpleKCM {
     property alias cfg_delay: delay.value
     property alias cfg_bold: bold.checked
     property alias cfg_debug: debug.checked
+    property alias cfg_enableGPU: enableGPU.checked
 
     Kirigami.FormLayout {
 
@@ -20,6 +21,12 @@ SimpleKCM {
         Controls.CheckBox {
             id: debug
             text: "Enable Debug Logging"
+            LayoutMirroring.enabled: true
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+        Controls.CheckBox {
+            id: enableGPU
+            text: "Enable AMD GPU Power Monitoring"
             LayoutMirroring.enabled: true
             anchors.horizontalCenter: parent.horizontalCenter
         }

--- a/package/contents/ui/ConfigGeneral.qml
+++ b/package/contents/ui/ConfigGeneral.qml
@@ -7,12 +7,19 @@ SimpleKCM {
     id: configItem
     property alias cfg_delay: delay.value
     property alias cfg_bold: bold.checked
+    property alias cfg_debug: debug.checked
 
     Kirigami.FormLayout {
 
         Controls.CheckBox {
             id: bold
             text: "Use Bold Text "
+            LayoutMirroring.enabled: true
+            anchors.horizontalCenter: parent.horizontalCenter
+        }
+        Controls.CheckBox {
+            id: debug
+            text: "Enable Debug Logging"
             LayoutMirroring.enabled: true
             anchors.horizontalCenter: parent.horizontalCenter
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -31,6 +31,7 @@ PlasmoidItem { // Main component of the plasmoid
     property double newNRG: 0 // State variable, used for storing new energy value
     property double oldTime: 0 // State variable, to store old time
     property string raplPath: "/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0/energy_uj" // Path to file which stores the energy information
+    property bool debug: plasmoid.configuration.debug // Read debug config
 
     // The main UI component, shows simple text
     fullRepresentation: PlasmaComponents.Label {
@@ -82,14 +83,18 @@ PlasmoidItem { // Main component of the plasmoid
     function update() {
         // Code to recalculate new power draw and update the UI
         executable.exec('cat ' + root.raplPath);
-        console.log(root.newNRG);
-        print(root.newNRG);
+        if (root.debug) {
+            console.log(root.newNRG);
+            print(root.newNRG);
+        }
         if (root.newNRG == '') {
             root.power = 'FX-PR';
         } else {
             var time = (new Date).getTime();
             var timeDelta = (time - root.oldTime) / 1000;
-            console.log(timeDelta);
+            if (root.debug) {
+                console.log(timeDelta);
+            }
             var joules = parseInt(root.newNRG) / 1e+06;
             root.power = Math.round((joules - root.oldNRG) * 10 / (timeDelta)) / 10;
             root.oldNRG = joules;


### PR DESCRIPTION
A debug switch has been added to the configuration. You can now enable or disable logging via the "Enable Debug Logging" checkbox in the settings. When disabled, the logs will not clutter the system journal.